### PR TITLE
Fixing up script support, adding support for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,18 @@ Puppet Labs NodeJS
   }
 </pre>
 
+# Environment Variables
+Some scripts require environment variables to be set at run time. this can be acheived with the environment option:
+
+<pre>
+  class { 'hubot':
+    adapter => 'irc',
+    irc_nickname => 'crunchy',
+    irc_server   => 'irc.freenode.com',
+    irc_rooms    => ['#soggies'],
+    environment  => [ 'MYVAR=VAR1', 'THISVAR=that' ],
+  }
+</pre>
 # TODO
-- Add Campfire support to Init Script/packages.js
-- Validate Ubuntu Support
 - Add Redhat Support?
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,8 @@ class hubot::config (
   $campfire_account = undef,
   $campfire_rooms = undef,
   $campfire_token = undef,
-  $vagrant_hubot
+  $vagrant_hubot,
+  $environment = undef
 ) inherits hubot::params {
 
   # Sanity check config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class hubot (
   $campfire_account = undef,
   $campfire_rooms   = undef,
   $campfire_token   = undef,
+  $environment      = undef,
 ) inherits hubot::params {
   include stdlib
 
@@ -33,6 +34,7 @@ class hubot (
     campfire_rooms   => $campfire_rooms,
     campfire_token   => $campfire_token,
     vagrant_hubot    => $vagrant_hubot,
+    environment      => $environment,
   }
   ~> class { 'hubot::service': }
   -> anchor { 'hubot::end': }

--- a/manifests/script.pp
+++ b/manifests/script.pp
@@ -28,8 +28,8 @@ define hubot::script (
   # the user an attribute they can set 
   # to make sure that all is good with the world.
   case $format {
-    js,javascript: { $file_extension = '.js' }
-    cs,coffee,coffeescript: { $file_extension = '.coffee' }
+    js,javascript: { $file_extension = 'js' }
+    cs,coffee,coffeescript: { $file_extension = 'coffee' }
     default: {
       fail("Unsupported Type: ${type}. Allowed are: js,javascript| cs,coffee,coffeescript")
     }
@@ -42,12 +42,12 @@ define hubot::script (
       exec { "download hubot script: ${name}":
         command => "wget ${source} -O ${REAL_install_dir}/scripts/${name}.${file_extension}",
         creates => "${REAL_install_dir}/scripts/${name}.${file_extension}",
+	notify  => File["${REAL_install_dir}/scripts/${name}.${file_extension}"],
       }
       # Ensure Puppet knows about the file
       # to ensure the File-Fragment is okay.
       file { "${REAL_install_dir}/scripts/${name}.${file_extension}":
-        ensure   => file,
-        requires => Exec["download hubot script: ${name}"],
+        ensure       => file,
       }
     }
     puppet,local: {

--- a/templates/hubot.init.erb
+++ b/templates/hubot.init.erb
@@ -34,7 +34,11 @@ export HUBOT_CAMPFIRE_ROOMS='<%= campfire_rooms.join(",") %>'
 export HUBOT_CAMPFIRE_TOKEN='<%= campfire_token %>'
 export HUBOT_OPTS="-a $HUBOT_ADAPTER"
 <% end -%>
-
+<% if @environment -%>
+<% environment.each do |var| -%>
+export <%= var %>
+<% end -%>
+<% end -%>
 set -e
 
 start_bot ()


### PR DESCRIPTION
Scripts were not working correctly on my Ubuntu installation with 2.7 so this fixes that up.

Some scripts need environment variables set, so I've added custom env vars support into the init script.

Added some brief doco to describe the usage.
