### PR TITLE
Fix: launching a new hubot on every puppet run

### DIFF
--- a/templates/hubot.init.erb
+++ b/templates/hubot.init.erb
@@ -69,7 +69,7 @@ restart)  log_daemon_msg "Restarting Hubot" "hubot"
           start_bot
           ;;
 status)   log_action_begin_msg "Checking Hubot"
-          if pidofproc -p "$PIDFILE" >/dev/null; then
+          if pidofproc -p "$PIDFILE" node >/dev/null; then
             log_action_end_msg 0 "running"
             exit 0
           else


### PR DESCRIPTION
Issue, pidofproc requires a path argument

local@hubot:/opt/hubot/scripts$ sudo /etc/init.d/hubot status
 * Checking Hubot...
/etc/init.d/hubot: invalid arguments

ran into this on Ubuntu 14.04